### PR TITLE
fix: reset db before running 2nd test

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -50,6 +50,7 @@ jobs:
           RAILS_ENV: "test"
           DATABASE_URL: "postgres://postgres@localhost:5432/rails_transaction_task_test"
         run: |
+          bundle exec rails db:reset
           bundle exec rspec
         continue-on-error: true
       - uses: JasonEtco/create-an-issue@v2


### PR DESCRIPTION
GitHub Actionsで2回 `bundle exec rspec` をしていますが、1回目の実行で作ったテストデータは特に後始末されていませんでした。

そのため、2回目の `bundle exec rspec` では、本当のテストの実行結果が出てくる前に、すでにユーザーが存在しているというエラーが出てしまっていました。

```
Failures:

  1) 発注機能 2人のユーザが同じ商品を同時に5個ずつ注文した場合 その商品の注文数が合計10個になること
     Failure/Error: let!(:user1){FactoryBot.create(:user)}

     ActiveRecord::RecordInvalid:
       Validation failed: Email has already been taken
     # ./spec/models/order_spec.rb:4:in `block (2 levels) in <top (required)>'

Finished in 1.03 seconds (files took 0.97682 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/models/order_spec.rb:27 # 発注機能 2人のユーザが同じ商品を同時に5個ずつ注文した場合 その商品の注文数が合計10個になること
```

ので、2回目のテスト実行前に `rails db:reset` して前世の記憶を消しておく必要があるかと思います！